### PR TITLE
Implement detection/error-handling

### DIFF
--- a/bmetest.py
+++ b/bmetest.py
@@ -1,10 +1,14 @@
-from bme680 import *
-from machine import I2C, Pin
-import time
-bme = BME680_I2C(I2C(-1, Pin(13), Pin(12)))
+try: from bme680 import *
+except: pass
+try: from machine import I2C, Pin
+except: pass
+from time import sleep
 
-for _ in range(3):
-    print(bme.temperature, bme.humidity, bme.pressure, bme.gas)
-    time.sleep(1)
+try:
+    bme = BME680_I2C(I2C(-1, Pin(13), Pin(12)))
 
-
+    for _ in range(3):
+        print(bme.temperature, bme.humidity, bme.pressure, bme.gas)
+        sleep(1)
+except:
+    print("BME680 not detected")


### PR DESCRIPTION
This is a very rough approach at implementing some quick error checking during the detection of the BME680, such that parent code calling this module can react sanely to a missing device.

It's probably not completely fleshed out (what happens when the device disappears after initialization?)   but it's at least conceptually working during trial runs.

