### PR TITLE
FIXED version of implementing error checking

### DIFF
--- a/bme680.py
+++ b/bme680.py
@@ -101,7 +101,7 @@ class Adafruit_BME680:
            reads."""
 
         result = self.is_detected()
-        if result = 0:
+        if result == 0:
             self._read_calibration()
 
             # set up heater
@@ -178,24 +178,6 @@ class Adafruit_BME680:
         else:
             raise RuntimeError("Invalid size")
 
-    @is_detected
-    def is_detected(self):
-        """Check if the BME680 was found"""
-        self._write(_BME680_REG_SOFTRESET, [0xB6])
-        time.sleep(0.005)
-
-        # Check device ID.
-        chip_id = self._read_byte(_BME680_REG_CHIPID)
-        # No chip found at this address
-        if chip_id is None:
-            return(-1)
-        # Unsupported chip found at this address
-        if chip_id != _BME680_CHIPID:
-            return(1)
-        # Detected
-        return(0)
-
-
     @property
     def temperature(self):
         """The compensated temperature in degrees celsius."""
@@ -267,6 +249,22 @@ class Adafruit_BME680:
         var3 = (_LOOKUP_TABLE_2[self._gas_range] * var1) / 512
         calc_gas_res = (var3 + (var2 / 2)) / var2
         return int(calc_gas_res)
+
+    def is_detected(self):
+        """Check if the BME680 was found"""
+        self._write(_BME680_REG_SOFTRESET, [0xB6])
+        time.sleep(0.005)
+
+        # Check device ID.
+        chip_id = self._read_byte(_BME680_REG_CHIPID)
+        # No chip found at this address
+        if chip_id is None:
+            return(-1)
+        # Unsupported chip found at this address
+        if chip_id != _BME680_CHIPID:
+            return(1)
+        # Detected
+        return(0)
 
     def _perform_reading(self):
         """Perform a single-shot reading from the sensor and fill internal data structure for

--- a/bmetest.py
+++ b/bmetest.py
@@ -1,10 +1,14 @@
-from bme680 import *
-from machine import I2C, Pin
-import time
-bme = BME680_I2C(I2C(-1, Pin(13), Pin(12)))
+try: from bme680 import *
+except: pass
+try: from machine import I2C, Pin
+except: pass
+from time import sleep
 
-for _ in range(3):
-    print(bme.temperature, bme.humidity, bme.pressure, bme.gas)
-    time.sleep(1)
+try:
+    bme = BME680_I2C(I2C(-1, Pin(13), Pin(12)))
 
-
+    for _ in range(3):
+        print(bme.temperature, bme.humidity, bme.pressure, bme.gas)
+        sleep(1)
+except:
+    print("BME680 not detected")


### PR DESCRIPTION
This is a very rough approach at implementing some quick error checking during the detection of the BME680, such that parent code calling this module can react sanely to a missing device.

It's probably not completely fleshed out (what happens when the device disappears after initialization?) but it's at least conceptually working during trial runs.

